### PR TITLE
feat: [FFM-6578]: Update JS SDK to 1.8.0 and expose `initialEvaluations` and `onError` props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 .idea
 .DS_Store
 dist
+junit.xml

--- a/README.md
+++ b/README.md
@@ -114,9 +114,11 @@ using the `useFeatureFlag` and `useFeatureFlags` hooks and `withFeatureFlags`
 [HOC](https://reactjs.org/docs/higher-order-components.html). At minimum, it requires the `apiKey` you have set up in
 your Harness Feature Flags account, and the `target`. You can think of a `target` as a user.
 
-The `FFContextProvider` component also accepts an `options` object, a `fallback` component and can be placed in
-[Async mode](#Async-mode) using the `async` prop. The `fallback` component will be displayed while the SDK is connecting
-and fetching your flags.
+The `FFContextProvider` component also accepts an `options` object, a `fallback` component, an array
+of `initialEvaluations`, an `onError` handler, and can be placed in [Async mode](#Async-mode) using the `async` prop.
+The `fallback` component will be displayed while the SDK is connecting and fetching your flags. The `initialEvaluations`
+prop allows you pass an array of evaluations to use immediately as the SDK is authenticating and fetching flags.
+The `onError` prop allows you to pass an event handler which will be called whenever a network error occurs.
 
 ```typescript jsx
 import { FFContextProvider } from '@harnessio/ff-react-client-sdk'
@@ -137,14 +139,17 @@ function MyComponent() {
         }
       }}
       fallback={<p>Loading ...</p>} // OPTIONAL: component to display when the SDK is connecting
-      options={{ // OPTIONAL: advanced options
+      options={{ // OPTIONAL: advanced configuration options
         baseUrl: 'https://url-to-access-flags.com',
         eventUrl: 'https://url-for-events.com',
         streamEnabled: true,
         allAttributesPrivate: false,
         privateAttributeNames: ['customAttribute'],
-        debug: true
+        debug: true,
+        eventsSyncInterval: 60000
       }}
+      initialEvaluations={evals} // OPTIONAL: array of evaluations to use while fetching
+      onError={handler} // OPTIONAL: event handler to be called on network error
     >
       <CompontToDisplayAfterLoad /> <!-- component to display when Flags are available -->
     </FFContextProvider>

--- a/examples/get-started/package-lock.json
+++ b/examples/get-started/package-lock.json
@@ -22,10 +22,10 @@
     },
     "../..": {
       "name": "@harnessio/ff-react-client-sdk",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.4.14",
+        "@harnessio/ff-javascript-client-sdk": "^1.8.0",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -39,6 +39,7 @@
         "@types/react-dom": "^18.0.6",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
+        "jest-junit": "^15.0.0",
         "prettier": "^2.7.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1188,9 +1189,9 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -1819,7 +1820,7 @@
         "@babel/preset-env": "^7.18.10",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
-        "@harnessio/ff-javascript-client-sdk": "^1.4.14",
+        "@harnessio/ff-javascript-client-sdk": "^1.8.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@types/lodash.omit": "^4.5.7",
@@ -1827,6 +1828,7 @@
         "@types/react-dom": "^18.0.6",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
+        "jest-junit": "^15.0.0",
         "lodash.omit": "^4.5.0",
         "prettier": "^2.7.1",
         "react": "^18.2.0",
@@ -2244,9 +2246,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "loose-envify": {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -13,6 +13,7 @@ const config: Config.InitialOptions = {
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.test.{ts,tsx}'],
   coverageReporters: ['lcov', 'json-summary', 'json'],
+  reporters: ['default', 'jest-junit'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-react-client-sdk",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.4.14",
+        "@harnessio/ff-javascript-client-sdk": "^1.8.0",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -23,6 +23,7 @@
         "@types/react-dom": "^18.0.6",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
+        "jest-junit": "^15.0.0",
         "prettier": "^2.7.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1840,9 +1841,9 @@
       }
     },
     "node_modules/@harnessio/ff-javascript-client-sdk": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.4.14.tgz",
-      "integrity": "sha512-VJsScAE6Lb5m4HZg5yxFUMFKNef4YGkVIApMsvUukkqXiIz+uEhqp44Lj8i76oe26vfcipmLCba5nVSNxln++g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.8.0.tgz",
+      "integrity": "sha512-IuZVFm6aENO8dL0aoeC5wNP/MLRsmftsV1+oyd16+XD8+uIyGPSj8W6jCUWspELINJp96KNv8mxLyAkf3rpO+w==",
       "dependencies": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"
@@ -5277,6 +5278,21 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-15.0.0.tgz",
+      "integrity": "sha512-Z5sVX0Ag3HZdMUnD5DFlG+1gciIFSy7yIVPhOdGUi8YJaI9iLvvBb530gtQL2CHmv0JJeiwRZenr0VrSR7frvg==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
@@ -6493,9 +6509,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -6718,6 +6734,18 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
       "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -7858,6 +7886,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -8064,6 +8101,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",
@@ -9402,9 +9445,9 @@
       }
     },
     "@harnessio/ff-javascript-client-sdk": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.4.14.tgz",
-      "integrity": "sha512-VJsScAE6Lb5m4HZg5yxFUMFKNef4YGkVIApMsvUukkqXiIz+uEhqp44Lj8i76oe26vfcipmLCba5nVSNxln++g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.8.0.tgz",
+      "integrity": "sha512-IuZVFm6aENO8dL0aoeC5wNP/MLRsmftsV1+oyd16+XD8+uIyGPSj8W6jCUWspELINJp96KNv8mxLyAkf3rpO+w==",
       "requires": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"
@@ -12053,6 +12096,18 @@
         "walker": "^1.0.8"
       }
     },
+    "jest-junit": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-15.0.0.tgz",
+      "integrity": "sha512-Z5sVX0Ag3HZdMUnD5DFlG+1gciIFSy7yIVPhOdGUi8YJaI9iLvvBb530gtQL2CHmv0JJeiwRZenr0VrSR7frvg==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      }
+    },
     "jest-leak-detector": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
@@ -12972,9 +13027,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jwt-decode": {
@@ -13146,6 +13201,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
       "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -13965,6 +14026,12 @@
         "requires-port": "^1.0.0"
       }
     },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
+    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -14114,6 +14181,12 @@
       "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "dev": true,
       "requires": {}
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "module": "dist/esm/index.js",
@@ -21,7 +21,7 @@
     "react": ">=16.7.0"
   },
   "dependencies": {
-    "@harnessio/ff-javascript-client-sdk": "^1.4.14",
+    "@harnessio/ff-javascript-client-sdk": "^1.8.0",
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {
@@ -35,6 +35,7 @@
     "@types/react-dom": "^18.0.6",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
+    "jest-junit": "^15.0.0",
     "prettier": "^2.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
This PR updates the JS SDK to the latest version and exposes `initialEvaluations` as a prop to use the `setEvaluations` method of the JS SDK. This PR also introduces the `onError` prop to allow the user to listen for network errors that may occur when authenticating, fetching flags, posting metrics or streaming.