### PR TITLE
chore: [FFM-6891]: Update JS SDK and caching docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ The React Client SDK's asynchronous mode allows this by passing the optional `as
 ## Caching evaluations
 
 In practice flags rarely change and so it can be useful to cache the last received evaluations from the server to allow
-your application to get started as fast as possible. Setting the `cache` option as `true` will allow the SDK to store
-its evaluations to `localStorage` and retrieve at startup. This lets the SDK get started near instantly and begin
-serving flags, while it carries on authenticating and fetching up-to-date evaluations from the server behind the scenes.
+your application to get started as fast as possible. Setting the `cache` option as `true` or as an object (see interface
+below) will allow the SDK to store its evaluations to `localStorage` and retrieve at startup. This lets the SDK get
+started near instantly and begin serving flags, while it carries on authenticating and fetching up-to-date evaluations
+from the server behind the scenes.
 
 ```typescript jsx
 <FFContextProvider
@@ -125,6 +126,14 @@ serving flags, while it carries on authenticating and fetching up-to-date evalua
 >
   <MyApp />
 </FFContextProvider>
+```
+
+The `cache` option can also be passed as an object with the following options.
+
+```typescript
+export interface CacheOptions {
+  ttl?: number // maximum age of stored cache, in ms, before it is considered stale
+}
 ```
 
 ## API

--- a/examples/get-started/package-lock.json
+++ b/examples/get-started/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.9.1",
+        "@harnessio/ff-javascript-client-sdk": "^1.10.0",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -1820,7 +1820,7 @@
         "@babel/preset-env": "^7.18.10",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
-        "@harnessio/ff-javascript-client-sdk": "^1.9.1",
+        "@harnessio/ff-javascript-client-sdk": "^1.10.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@types/lodash.omit": "^4.5.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.9.1",
+        "@harnessio/ff-javascript-client-sdk": "^1.10.0",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -1841,10 +1841,11 @@
       }
     },
     "node_modules/@harnessio/ff-javascript-client-sdk": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.9.1.tgz",
-      "integrity": "sha512-iueEjqYdyizWQ8X7CgHZs7EnLzNttI59TQBKy2vxebZYXoGyZHw78rxrv4IHFeXfx6BUwkQty1Iw1UPqHI1lYA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.10.0.tgz",
+      "integrity": "sha512-QxTRxytvyvjnyneSwN+/UzV04ArJPsSfdy+xOyDHjWItlhOQcuJt+k8CBFotNvoVtyAVM+BoEQ7kyh+mZ4Xccw==",
       "dependencies": {
+        "event-source-polyfill": "1.0.31",
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"
       }
@@ -3992,6 +3993,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA=="
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -9445,10 +9451,11 @@
       }
     },
     "@harnessio/ff-javascript-client-sdk": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.9.1.tgz",
-      "integrity": "sha512-iueEjqYdyizWQ8X7CgHZs7EnLzNttI59TQBKy2vxebZYXoGyZHw78rxrv4IHFeXfx6BUwkQty1Iw1UPqHI1lYA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.10.0.tgz",
+      "integrity": "sha512-QxTRxytvyvjnyneSwN+/UzV04ArJPsSfdy+xOyDHjWItlhOQcuJt+k8CBFotNvoVtyAVM+BoEQ7kyh+mZ4Xccw==",
       "requires": {
+        "event-source-polyfill": "1.0.31",
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"
       }
@@ -11142,6 +11149,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA=="
     },
     "execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": ">=16.7.0"
   },
   "dependencies": {
-    "@harnessio/ff-javascript-client-sdk": "^1.9.1",
+    "@harnessio/ff-javascript-client-sdk": "^1.10.0",
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the JS SDK version to v1.10.0 and updates the caching docs to explain how to use TTL.