### PR TITLE
feat: [FFM-10886]: Update JS SDK to 1.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,43 @@ interface AsyncStorage {
 }
 ```
 
+## Overriding the internal logger
+
+By default, the React Client SDK will log errors and debug messages using the `console` object. In some cases, it
+can be useful to instead log to a service or silently fail without logging errors.
+
+```typescript jsx
+const myLogger = {
+  debug: (...data) => {
+    // do something with the logged debug message
+  },
+  info: (...data) => {
+    // do something with the logged info message
+  },
+  error: (...data) => {
+    // do something with the logged error message
+  },
+  warn: (...data) => {
+    // do something with the logged warning message
+  }
+}
+
+return (
+  <FFContextProvider
+    apiKey="YOUR_API_KEY"
+    target={{
+      identifier: 'reactclientsdk',
+      name: 'ReactClientSDK'
+    }}
+    options={{
+      logger: myLogger
+    }}
+  >
+    <MyApp />
+  </FFContextProvider>
+)
+```
+
 ## API
 
 ### `FFContextProvider`

--- a/examples/get-started/package-lock.json
+++ b/examples/get-started/package-lock.json
@@ -22,10 +22,10 @@
     },
     "../..": {
       "name": "@harnessio/ff-react-client-sdk",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.25.0",
+        "@harnessio/ff-javascript-client-sdk": "^1.26.0",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -1833,7 +1833,7 @@
         "@babel/preset-env": "^7.18.10",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
-        "@harnessio/ff-javascript-client-sdk": "^1.25.0",
+        "@harnessio/ff-javascript-client-sdk": "^1.26.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@types/lodash.omit": "^4.5.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-react-client-sdk",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.25.0",
+        "@harnessio/ff-javascript-client-sdk": "^1.26.0",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -1843,9 +1843,9 @@
       }
     },
     "node_modules/@harnessio/ff-javascript-client-sdk": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.25.0.tgz",
-      "integrity": "sha512-drYse0T2KpfKm62JBzI7aOjODWG7+oC1AkhPapeMzabjP5v6227wx+7+2+Qz3VR5Y/GS1Xd73H92MNmpPhAP9A==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.26.0.tgz",
+      "integrity": "sha512-BxGoSuYs3D6CvSAAqjroCjluUJlK8+fIXn3L5ouaTjfANOu2tYEBOZvVeGokKK+/rh5EXxolcnLiOXJQxFwlYA==",
       "dependencies": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"
@@ -9451,9 +9451,9 @@
       }
     },
     "@harnessio/ff-javascript-client-sdk": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.25.0.tgz",
-      "integrity": "sha512-drYse0T2KpfKm62JBzI7aOjODWG7+oC1AkhPapeMzabjP5v6227wx+7+2+Qz3VR5Y/GS1Xd73H92MNmpPhAP9A==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.26.0.tgz",
+      "integrity": "sha512-BxGoSuYs3D6CvSAAqjroCjluUJlK8+fIXn3L5ouaTjfANOu2tYEBOZvVeGokKK+/rh5EXxolcnLiOXJQxFwlYA==",
       "requires": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "module": "dist/esm/index.js",
@@ -21,7 +21,7 @@
     "react": ">=16.7.0"
   },
   "dependencies": {
-    "@harnessio/ff-javascript-client-sdk": "^1.25.0",
+    "@harnessio/ff-javascript-client-sdk": "^1.26.0",
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the internal JS SDK to 1.26.0 and updates the README with details on overriding the logger.