### PR TITLE
chore: [FFM-11353]: Reduce ES target to 2018 and update JS SDK

### DIFF
--- a/examples/get-started/package-lock.json
+++ b/examples/get-started/package-lock.json
@@ -22,10 +22,10 @@
     },
     "../..": {
       "name": "@harnessio/ff-react-client-sdk",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.26.0",
+        "@harnessio/ff-javascript-client-sdk": "^1.26.2",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -1833,7 +1833,7 @@
         "@babel/preset-env": "^7.18.10",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
-        "@harnessio/ff-javascript-client-sdk": "^1.26.0",
+        "@harnessio/ff-javascript-client-sdk": "^1.26.2",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@types/lodash.omit": "^4.5.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-react-client-sdk",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.26.0",
+        "@harnessio/ff-javascript-client-sdk": "^1.26.2",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -1843,9 +1843,9 @@
       }
     },
     "node_modules/@harnessio/ff-javascript-client-sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.26.0.tgz",
-      "integrity": "sha512-BxGoSuYs3D6CvSAAqjroCjluUJlK8+fIXn3L5ouaTjfANOu2tYEBOZvVeGokKK+/rh5EXxolcnLiOXJQxFwlYA==",
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.26.2.tgz",
+      "integrity": "sha512-K79xKt0sfFcT8ft+/EgEz3jRbaHnUdR8uEM4bjo6RnOa+gqQzpoQjSdl3/hAUYCJ0k6tKFAqhTE2b8iHOdGnPg==",
       "dependencies": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"
@@ -9451,9 +9451,9 @@
       }
     },
     "@harnessio/ff-javascript-client-sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.26.0.tgz",
-      "integrity": "sha512-BxGoSuYs3D6CvSAAqjroCjluUJlK8+fIXn3L5ouaTjfANOu2tYEBOZvVeGokKK+/rh5EXxolcnLiOXJQxFwlYA==",
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.26.2.tgz",
+      "integrity": "sha512-K79xKt0sfFcT8ft+/EgEz3jRbaHnUdR8uEM4bjo6RnOa+gqQzpoQjSdl3/hAUYCJ0k6tKFAqhTE2b8iHOdGnPg==",
       "requires": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "module": "dist/esm/index.js",
@@ -21,7 +21,7 @@
     "react": ">=16.7.0"
   },
   "dependencies": {
-    "@harnessio/ff-javascript-client-sdk": "^1.26.0",
+    "@harnessio/ff-javascript-client-sdk": "^1.26.2",
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": false,
     "outDir": "dist/esm",
-    "declaration": true
+    "declaration": true,
+    "target": "ES2018"
   },
   "exclude": ["src/**/__tests__"]
 }


### PR DESCRIPTION
This PR reduces the build target used for compilation from ES2020 to ES2018 for compatibility reasons. It also updates the JS SDK to the latest version.