### PR TITLE
FFM-11852 Bump JS SDK version / Patch CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.26.2",
+        "@harnessio/ff-javascript-client-sdk": "^1.27.0",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -1843,9 +1843,9 @@
       }
     },
     "node_modules/@harnessio/ff-javascript-client-sdk": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.26.2.tgz",
-      "integrity": "sha512-K79xKt0sfFcT8ft+/EgEz3jRbaHnUdR8uEM4bjo6RnOa+gqQzpoQjSdl3/hAUYCJ0k6tKFAqhTE2b8iHOdGnPg==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.27.0.tgz",
+      "integrity": "sha512-OvzbaiSg7NeJ/YkYE9WEWDJ7+93gEMMiCK/XCTksuJSyPMID/MpwKjMleJqvMpm+NW/GQpVIf8rXO49u3LWmKw==",
       "dependencies": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"
@@ -9451,9 +9451,9 @@
       }
     },
     "@harnessio/ff-javascript-client-sdk": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.26.2.tgz",
-      "integrity": "sha512-K79xKt0sfFcT8ft+/EgEz3jRbaHnUdR8uEM4bjo6RnOa+gqQzpoQjSdl3/hAUYCJ0k6tKFAqhTE2b8iHOdGnPg==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.27.0.tgz",
+      "integrity": "sha512-OvzbaiSg7NeJ/YkYE9WEWDJ7+93gEMMiCK/XCTksuJSyPMID/MpwKjMleJqvMpm+NW/GQpVIf8rXO49u3LWmKw==",
       "requires": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-react-client-sdk",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@harnessio/ff-javascript-client-sdk": "^1.26.2",
@@ -3448,12 +3448,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4063,9 +4063,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -8086,16 +8086,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -10735,12 +10735,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-process-hrtime": {
@@ -11198,9 +11198,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -14173,9 +14173,9 @@
       }
     },
     "ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": ">=16.7.0"
   },
   "dependencies": {
-    "@harnessio/ff-javascript-client-sdk": "^1.26.2",
+    "@harnessio/ff-javascript-client-sdk": "^1.27.0",
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# What
- Bumps JS SDK version to bring in a fix for fallback polling behaviour
- Patches CVEs:
    - [ws](https://github.com/advisories/GHSA-3h5v-q93c-6h6q)
    - [braces](https://github.com/advisories/GHSA-grv7-fg5c-xmjg)

# Testing
Manual using sample app. 