### PR TITLE
FFM-11972 FFM-11852 Bump JS SDK version / Patch CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@harnessio/ff-javascript-client-sdk": "^1.27.0",
+        "@harnessio/ff-javascript-client-sdk": "^1.28.0",
         "lodash.omit": "^4.5.0"
       },
       "devDependencies": {
@@ -1843,9 +1843,9 @@
       }
     },
     "node_modules/@harnessio/ff-javascript-client-sdk": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.27.0.tgz",
-      "integrity": "sha512-OvzbaiSg7NeJ/YkYE9WEWDJ7+93gEMMiCK/XCTksuJSyPMID/MpwKjMleJqvMpm+NW/GQpVIf8rXO49u3LWmKw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.28.0.tgz",
+      "integrity": "sha512-E9zykwFdlr7jwbxY5H3xwt3oYEQRIFVLlp2VL9m05kPZVTu+I5bw6Z9nYnyIyHNbJGm893ieVo4f3h6Ogqdm0A==",
       "dependencies": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"
@@ -6667,12 +6667,12 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -9451,9 +9451,9 @@
       }
     },
     "@harnessio/ff-javascript-client-sdk": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.27.0.tgz",
-      "integrity": "sha512-OvzbaiSg7NeJ/YkYE9WEWDJ7+93gEMMiCK/XCTksuJSyPMID/MpwKjMleJqvMpm+NW/GQpVIf8rXO49u3LWmKw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@harnessio/ff-javascript-client-sdk/-/ff-javascript-client-sdk-1.28.0.tgz",
+      "integrity": "sha512-E9zykwFdlr7jwbxY5H3xwt3oYEQRIFVLlp2VL9m05kPZVTu+I5bw6Z9nYnyIyHNbJGm893ieVo4f3h6Ogqdm0A==",
       "requires": {
         "jwt-decode": "^3.1.2",
         "mitt": "^2.1.0"
@@ -13149,12 +13149,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-react-client-sdk",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@harnessio/ff-javascript-client-sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-react-client-sdk",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": ">=16.7.0"
   },
   "dependencies": {
-    "@harnessio/ff-javascript-client-sdk": "^1.27.0",
+    "@harnessio/ff-javascript-client-sdk": "^1.28.0",
     "lodash.omit": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# What
- Bumps JS SDK version to bring in `authRequestReadTimeout` config option + auth failure log bug fix. 

- Patches https://github.com/advisories/GHSA-952p-6rrq-rcjv via `npm audit fix` .  This is found in micromatch which is used by dev dependencies and not shipped to users. It is found in the following packages:

    -`jest-environment-jsdom@28.1.3`
    -`jest@28.1.3`

# Testing
Smoke test using sample application:
- Auth
- Streaming